### PR TITLE
chore: upgrade viem to v2.33.3 and remove custom chain definitions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "@sablier/deployments",
       "dependencies": {
         "lodash": "^4.17.21",
-        "viem": "^2.31.7",
+        "viem": "^2.33.3",
       },
       "devDependencies": {
         "@biomejs/biome": "2.1.1",
@@ -28,7 +28,7 @@
         "winston": "^3.17",
       },
       "peerDependencies": {
-        "viem": "^2.31",
+        "viem": "^2.32",
       },
     },
   },
@@ -111,7 +111,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -429,7 +429,7 @@
 
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
-    "ox": ["ox@0.7.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg=="],
+    "ox": ["ox@0.8.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-eiKcgiVVEGDtEpEdFi1EGoVVI48j6icXHce9nFwCNM7CKG3uoCXKdr4TPhS00Iy1TR2aWSF1ltPD0x/YgqIL9w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -545,7 +545,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "viem": ["viem@2.31.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.7.1", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA=="],
+    "viem": ["viem@2.33.3", "", { "dependencies": { "@noble/curves": "1.9.2", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.8.6", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aWDr6i6r3OfNCs0h9IieHFhn7xQJJ8YsuA49+9T5JRyGGAkWhLgcbLq2YMecgwM7HdUZpx1vPugZjsShqNi7Gw=="],
 
     "vite": ["vite@6.3.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.3", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.12" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg=="],
 
@@ -568,6 +568,8 @@
     "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
     "yaml": ["yaml@2.7.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@types/fs-extra/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "viem": "^2.31.7"
+    "viem": "^2.33.3"
   },
   "peerDependencies": {
-    "viem": "^2.31"
+    "viem": "^2.32"
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.1",

--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -25,6 +25,8 @@ import {
   mode as _mode,
   modeTestnet as _modeTestnet,
   monadTestnet as _monadTestnet,
+  morph as _morph,
+  morphHolesky as _morphHolesky,
   optimism as _optimism,
   optimismSepolia as _optimismSepolia,
   polygon as _polygon,
@@ -38,8 +40,6 @@ import {
   taiko as _taiko,
   taikoHekla as _taikoHekla,
   unichain as _unichain,
-  morph as _morph,
-  morphHolesky as _morphHolesky,
   xdc as _xdc,
   zksync as _zksync,
   zksyncSepoliaTestnet as _zksyncSepoliaTestnet,
@@ -194,6 +194,7 @@ export const berachain = define("berachain", _berachain);
 export const blast = define("blast", _blast);
 export const blastSepolia = define("blast-sepolia", _blastSepolia);
 export const bsc = define("bsc", _bsc);
+export const chiliz = define("chiliz", _chiliz);
 export const coreDao = define("core-dao", _coreDao);
 export const form = define("form", _form);
 export const gnosis = define("gnosis", _gnosis);
@@ -206,6 +207,7 @@ export const meld = define("meld", _meld);
 export const mode = define("mode", _mode);
 export const modeTestnet = define("mode-testnet", _modeTestnet);
 export const monadTestnet = define("monad-testnet", _monadTestnet);
+export const morph = define("morph", _morph);
 export const morphHolesky = define("morph-holesky", _morphHolesky);
 export const optimism = define("optimism", _optimism);
 export const optimismSepolia = define("optimism-sepolia", _optimismSepolia);
@@ -223,8 +225,6 @@ export const xdc = define("xdc", _xdc);
 export const zksync = define("zksync", _zksync);
 export const zksyncSepolia = define("zksync-sepolia", _zksyncSepoliaTestnet);
 
-export const chiliz = define("chiliz", _chiliz);
-
 /**
  * HyperEVM is using another chain's ID (Wanchain Testnet). Until they change this, we will have to define it like this.
  * @see https://github.com/wevm/viem/pull/3390
@@ -238,7 +238,7 @@ export const hyperevm: Sablier.Chain = define(
     contracts: {
       multicall3: {
         address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-        blockCreated: 13051,
+        blockCreated: 13_051,
       },
     },
     id: 999,
@@ -259,8 +259,6 @@ export const hyperevm: Sablier.Chain = define(
     testnet: false,
   }),
 );
-
-export const morph = define("morph", _morph);
 
 export const sei: Sablier.Chain = define(
   "sei",
@@ -283,7 +281,7 @@ export const tangle: Sablier.Chain = define(
     contracts: {
       multicall3: {
         address: "0xd595D34ed96b253E7c7a934a7624F330a8411953",
-        blockCreated: 2790914,
+        blockCreated: 2_790_914,
       },
     },
     id: 5845,

--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -25,7 +25,6 @@ import {
   mode as _mode,
   modeTestnet as _modeTestnet,
   monadTestnet as _monadTestnet,
-  morphHolesky as _morphHolesky,
   optimism as _optimism,
   optimismSepolia as _optimismSepolia,
   polygon as _polygon,
@@ -39,7 +38,8 @@ import {
   taiko as _taiko,
   taikoHekla as _taikoHekla,
   unichain as _unichain,
-  morph as _viemMorph,
+  morph as _morph,
+  morphHolesky as _morphHolesky,
   xdc as _xdc,
   zksync as _zksync,
   zksyncSepoliaTestnet as _zksyncSepoliaTestnet,
@@ -223,24 +223,7 @@ export const xdc = define("xdc", _xdc);
 export const zksync = define("zksync", _zksync);
 export const zksyncSepolia = define("zksync-sepolia", _zksyncSepoliaTestnet);
 
-export const chiliz: Sablier.Chain = define(
-  "chiliz",
-  viemDefine({
-    ..._chiliz,
-    contracts: {
-      ..._chiliz.contracts,
-      multicall3: {
-        address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-        blockCreated: 8_080_847,
-      },
-    },
-    rpcUrls: {
-      default: {
-        http: ["https://rpc.ankr.com/chiliz", "https://chiliz-rpc.publicnode.com", "https://rpc.chiliz.com"],
-      },
-    },
-  }),
-);
+export const chiliz = define("chiliz", _chiliz);
 
 /**
  * HyperEVM is using another chain's ID (Wanchain Testnet). Until they change this, we will have to define it like this.
@@ -277,19 +260,7 @@ export const hyperevm: Sablier.Chain = define(
   }),
 );
 
-export const morph: Sablier.Chain = define(
-  "morph",
-  viemDefine({
-    ..._viemMorph,
-    contracts: {
-      ..._viemMorph.contracts,
-      multicall3: {
-        address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-        blockCreated: 3_654_913,
-      },
-    },
-  }),
-);
+export const morph = define("morph", _morph);
 
 export const sei: Sablier.Chain = define(
   "sei",


### PR DESCRIPTION
Fixes #16

## Summary

Upgraded Viem to v2.33.3 and removed custom Chiliz and Morph chain definitions as they are now included in Viem v2.32+.

## Changes
- Updated `viem` dependency from `^2.31.7` to `^2.33.3`
- Updated `viem` peer dependency from `^2.31` to `^2.32`
- Removed custom chain definitions for Chiliz and Morph from `src/chains/data.ts`
- Now using built-in chain definitions from Viem