### PR TITLE
fix: define custom chiliz

### DIFF
--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -233,7 +233,6 @@ export const berachain = define("berachain", _berachain);
 export const blast = define("blast", _blast);
 export const blastSepolia = define("blast-sepolia", _blastSepolia);
 export const bsc = define("bsc", _bsc);
-export const chiliz = define("chiliz", _chiliz);
 export const coreDao = define("core-dao", _coreDao);
 export const form = define("form", _form);
 export const gnosis = define("gnosis", _gnosis);
@@ -267,6 +266,21 @@ export const zksyncSepolia = define("zksync-sepolia", _zksyncSepoliaTestnet);
 /* -------------------------------------------------------------------------- */
 /*                             CUSTOM DEFINITIONS                             */
 /* -------------------------------------------------------------------------- */
+
+export const chiliz: Sablier.Chain = define(
+  "chiliz",
+  viemDefine({
+    ..._chiliz,
+    blockExplorers: {
+      default: { name: "Explorer", url: "https://chiliscan.com" },
+    },
+    rpcUrls: {
+      default: {
+        http: ["https://rpc.ankr.com/chiliz"],
+      },
+    },
+  }),
+);
 
 /**
  * HyperEVM is using another chain's ID (Wanchain Testnet). Until they change this, we will have to define it like this.

--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -276,7 +276,7 @@ export const chiliz: Sablier.Chain = define(
     },
     rpcUrls: {
       default: {
-        http: ["https://rpc.ankr.com/chiliz"],
+        http: ["https://rpc.chiliz.com"],
       },
     },
   }),


### PR DESCRIPTION
According to their docs, I added the custom Chiliz definition: https://docs.chiliz.com/quick-start/connect-to-mainnet-and-testnet

Now the explorer points to a different URL: https://scan.chiliz.com/address/0x28eAB88ee8a951F78e1028557D0C3fD97af61A33/contracts#address-tabs

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/c60fd995-b391-4e10-9160-c591a8389d2b" />

which doesn’t include verification.

Compared to: https://chiliscan.com/address/0x28eAB88ee8a951F78e1028557D0C3fD97af61A33/contract/88888/code

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/2e5d0054-ef3f-487d-930f-8a8e17609529" />
