### PR TITLE
chore: bump release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[1.2.0]: https://github.com/sablier-labs/sdk/releases/tag/v1.2.0
 [1.1.0]: https://github.com/sablier-labs/sdk/releases/tag/v1.1.0
 [1.0.0]: https://github.com/sablier-labs/sdk/releases/tag/v1.0.0
+
+## [1.2.0] - 2025-10-15
+
+### Added
+
+- Airdrops v2.0 release ([#38](https://github.com/sablier-labs/sdk/pull/38))
+- Flow v2.0 release ([#43](https://github.com/sablier-labs/sdk/pull/43))
+- Lockup v3.0 release ([#41](https://github.com/sablier-labs/sdk/pull/41))
+- Query support for same address across releases ([#48](https://github.com/sablier-labs/sdk/pull/48))
 
 ## [1.1.0] - 2025-08-21
 

--- a/deployments/airdrops/v2.0/README.md
+++ b/deployments/airdrops/v2.0/README.md
@@ -9,10 +9,8 @@
 
 ## Sources
 
-<!-- TODO: update commit after launch -->
-
-- Commit: [9572d6e](https://github.com/sablier-labs/airdrops/commit/9572d6e8029e13e93606a07114de86d55eb2a75d)
-- Package: [@sablier/airdrops@2.0](https://npmjs.com/package/@sablier/airdrops/v/2.0.0)
+- Commit: [077c6b9](https://github.com/sablier-labs/airdrops/commit/077c6b9766ef7693ba9e82a9e001dc0097709c01)
+- Package: [@sablier/airdrops@2.0.1](https://npmjs.com/package/@sablier/airdrops/v/2.0.1)
 
 ## Configurations
 

--- a/deployments/flow/v2.0/README.md
+++ b/deployments/flow/v2.0/README.md
@@ -6,10 +6,8 @@
 
 ## Sources
 
-<!-- TODO: update commit after launch -->
-
-- Commit: [fe7cf4e](https://github.com/sablier-labs/flow/commit/2959b41c85f50ee527132b733fa6e817fbe5a727)
-- Package: [@sablier/flow@3.0.0](https://npmjs.com/package/@sablier/flow/v/2.0.0)
+- Commit: [a4143de](https://github.com/sablier-labs/flow/commit/a4143de45478f508bca8305fec2bd81b7ad25fe9)
+- Package: [@sablier/flow@2.0.0](https://npmjs.com/package/@sablier/flow/v/2.0.0)
 
 ## Configurations
 

--- a/deployments/lockup/v3.0/README.md
+++ b/deployments/lockup/v3.0/README.md
@@ -9,10 +9,8 @@
 
 ## Sources
 
-<!-- TODO: update commit after launch -->
-
-- Commit: [fe7cf4e](https://github.com/sablier-labs/lockup/commit/fe7cf4eeab1b316dbc1fa5da086a3b266f6b4079)
-- Package: [@sablier/lockup@3.0.0](https://npmjs.com/package/@sablier/lockup/v/3.0.0)
+- Commit: [0c3ea98](https://github.com/sablier-labs/lockup/commit/0c3ea987b00f12a57274556cd84bddaab92f5a16)
+- Package: [@sablier/lockup@3.0.1](https://npmjs.com/package/@sablier/lockup/v/3.0.1)
 
 ## Configurations
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sablier",
   "description": "Contract addresses, chain data, and deployment information for the Sablier Protocol",
-  "version": "1.2.0-beta.4",
+  "version": "1.2.0",
   "author": {
     "name": "Sablier Labs Ltd",
     "url": "https://sablier.com"


### PR DESCRIPTION
Replacement for https://github.com/sablier-labs/sdk/pull/51