### PR TITLE
fix: update Polygon CoinGecko ID to polygon-ecosystem-token

### DIFF
--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -132,7 +132,7 @@ const config = {
     [_iotex.nativeCurrency.symbol]: "iotex",
     [_meld.nativeCurrency.symbol]: "meld-2",
     [_monadTestnet.nativeCurrency.symbol]: "monad",
-    [_polygon.nativeCurrency.symbol]: "matic-network",
+    [_polygon.nativeCurrency.symbol]: "polygon-ecosystem-token",
     [_ronin.nativeCurrency.symbol]: "ronin",
     [_sei.nativeCurrency.symbol]: "sei",
     [_sophon.nativeCurrency.symbol]: "sophon",


### PR DESCRIPTION
Updates the Polygon CoinGecko ID from `matic-network` to `polygon-ecosystem-token`. This ensures correct price and market data fetching for Polygon chain.

The old ID (`matic-network`) refers to the legacy MATIC token, while the new ID corresponds to the rebranded POL token.