### PR TITLE
feat: add RouteMesh RPC support

### DIFF
--- a/src/chains/data.ts
+++ b/src/chains/data.ts
@@ -111,6 +111,15 @@ const infuraRPCs: Record<number, RPCGenerator> = {
   [_zksync.id]: (apiKey) => `https://zksync-mainnet.infura.io/v3/${apiKey}`,
 };
 
+/**
+ * RouteMesh uses a deterministic URL pattern based on chain ID, supporting all chains.
+ * @see https://routeme.sh/dashboard/chains
+ */
+const routemeshRPC =
+  (chainId: number): RPCGenerator =>
+  (apiKey) =>
+    `https://lb.routeme.sh/rpc/${chainId}/${apiKey}`;
+
 /* -------------------------------------------------------------------------- */
 /*                                   HELPERS                                  */
 /* -------------------------------------------------------------------------- */
@@ -214,6 +223,7 @@ function define(slug: string, chain: ViemChain): Sablier.Chain {
       alchemy: alchemyRPCs[chain.id],
       defaults: defaultRPCs as string[],
       infura: infuraRPCs[chain.id],
+      routemesh: routemeshRPC(chain.id),
     },
     slug,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export namespace Sablier {
       defaults: string[];
       /** Infura RPC URL generator. */
       infura?: (apiKey: string) => string;
+      /** RouteMesh RPC URL generator. */
+      routemesh?: (apiKey: string) => string;
     };
     /** Used in deployment files to identify the chain, e.g., arbitrum-sepolia. */
     slug: string;


### PR DESCRIPTION
## Summary

Adds RouteMesh as an RPC provider option for all chains, using their deterministic URL pattern based on chain ID.

## Changes

- Added `routemeshRPC` generator function supporting all chains via `lb.routeme.sh/rpc/{chainId}/{apiKey}`
- Updated chain definition to include `routemesh` RPC option alongside existing Alchemy and Infura providers

Closes https://github.com/sablier-labs/sdk/issues/57