### PR TITLE
feat: add version comparison utilities

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,3 +13,49 @@ export function getContractExplorerURL(explorerURL: string, contractAddress: Sab
 export function sortChains<T extends { name: string }>(chains: T[]): T[] {
   return chains.sort((a, b) => a.name.localeCompare(b.name));
 }
+
+/**
+ * Compare two semantic version strings.
+ * @param a - First version string (e.g., "v1.0", "v2.1")
+ * @param b - Second version string (e.g., "v1.0", "v2.1")
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b
+ * @example
+ * compareVersions("v1.0", "v2.0") // -1
+ * compareVersions("v2.0", "v1.0") // 1
+ * compareVersions("v1.1", "v1.1") // 0
+ */
+export function compareVersions(a: Sablier.Version, b: Sablier.Version): number {
+  const [aMajor, aMinor] = a.slice(1).split(".").map(Number);
+  const [bMajor, bMinor] = b.slice(1).split(".").map(Number);
+
+  if (aMajor !== bMajor) {
+    return aMajor - bMajor;
+  }
+  return aMinor - bMinor;
+}
+
+/**
+ * Check if a version comes before another chronologically.
+ * @param version - The version to check
+ * @param before - The reference version to compare against
+ * @returns true if version comes before the reference version
+ * @example
+ * isVersionBefore("v1.0", "v2.0") // true
+ * isVersionBefore("v2.0", "v1.0") // false
+ */
+export function isVersionBefore(version: Sablier.Version, before: Sablier.Version): boolean {
+  return compareVersions(version, before) < 0;
+}
+
+/**
+ * Check if a version comes after another chronologically.
+ * @param version - The version to check
+ * @param after - The reference version to compare against
+ * @returns true if version comes after the reference version
+ * @example
+ * isVersionAfter("v2.0", "v1.0") // true
+ * isVersionAfter("v1.0", "v2.0") // false
+ */
+export function isVersionAfter(version: Sablier.Version, after: Sablier.Version): boolean {
+  return compareVersions(version, after) > 0;
+}

--- a/tests/cron/coingecko.test.ts
+++ b/tests/cron/coingecko.test.ts
@@ -5,7 +5,6 @@
  * the CoinGecko API for each coin.
  */
 import axios from "axios";
-import _ from "lodash";
 import { describe, expect, it } from "vitest";
 
 const COINGECKO_API_KEY = process.env.VITE_COINGECKO_API_KEY;

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,119 @@
+import { Version } from "@src/enums";
+import { compareVersions, isVersionAfter, isVersionBefore } from "@src/helpers";
+import { describe, expect, it } from "vitest";
+
+describe("helpers", () => {
+  describe("compareVersions", () => {
+    it("returns 0 for equal versions", () => {
+      expect(compareVersions(Version.Lockup.V1_0, Version.Lockup.V1_0)).toBe(0);
+      expect(compareVersions(Version.Lockup.V2_0, Version.Lockup.V2_0)).toBe(0);
+      expect(compareVersions(Version.Flow.V1_1, Version.Flow.V1_1)).toBe(0);
+    });
+
+    it("returns negative when first version is older", () => {
+      expect(compareVersions(Version.Lockup.V1_0, Version.Lockup.V2_0)).toBeLessThan(0);
+      expect(compareVersions(Version.Lockup.V1_1, Version.Lockup.V2_0)).toBeLessThan(0);
+      expect(compareVersions(Version.Flow.V1_0, Version.Flow.V2_0)).toBeLessThan(0);
+      expect(compareVersions(Version.Airdrops.V1_1, Version.Airdrops.V2_0)).toBeLessThan(0);
+    });
+
+    it("returns positive when first version is newer", () => {
+      expect(compareVersions(Version.Lockup.V2_0, Version.Lockup.V1_0)).toBeGreaterThan(0);
+      expect(compareVersions(Version.Lockup.V2_0, Version.Lockup.V1_1)).toBeGreaterThan(0);
+      expect(compareVersions(Version.Flow.V2_0, Version.Flow.V1_0)).toBeGreaterThan(0);
+      expect(compareVersions(Version.Airdrops.V2_0, Version.Airdrops.V1_1)).toBeGreaterThan(0);
+    });
+
+    it("correctly compares minor version differences", () => {
+      expect(compareVersions(Version.Lockup.V1_0, Version.Lockup.V1_1)).toBeLessThan(0);
+      expect(compareVersions(Version.Lockup.V1_1, Version.Lockup.V1_2)).toBeLessThan(0);
+      expect(compareVersions(Version.Lockup.V1_2, Version.Lockup.V1_1)).toBeGreaterThan(0);
+      expect(compareVersions(Version.Flow.V1_0, Version.Flow.V1_1)).toBeLessThan(0);
+    });
+
+    it("correctly compares major version differences", () => {
+      expect(compareVersions(Version.Lockup.V1_2, Version.Lockup.V2_0)).toBeLessThan(0);
+      expect(compareVersions(Version.Lockup.V2_0, Version.Lockup.V3_0)).toBeLessThan(0);
+      expect(compareVersions(Version.Lockup.V3_0, Version.Lockup.V2_0)).toBeGreaterThan(0);
+    });
+
+    it("works across all protocol versions", () => {
+      // Lockup
+      expect(compareVersions(Version.Lockup.V1_0, Version.Lockup.V3_0)).toBeLessThan(0);
+
+      // Flow
+      expect(compareVersions(Version.Flow.V1_0, Version.Flow.V2_0)).toBeLessThan(0);
+
+      // Airdrops
+      expect(compareVersions(Version.Airdrops.V1_1, Version.Airdrops.V2_0)).toBeLessThan(0);
+
+      // Legacy
+      expect(compareVersions(Version.Legacy.V1_0, Version.Legacy.V1_1)).toBeLessThan(0);
+    });
+  });
+
+  describe("isVersionBefore", () => {
+    it("returns true when version is before reference", () => {
+      expect(isVersionBefore(Version.Lockup.V1_0, Version.Lockup.V2_0)).toBe(true);
+      expect(isVersionBefore(Version.Lockup.V1_1, Version.Lockup.V2_0)).toBe(true);
+      expect(isVersionBefore(Version.Lockup.V2_0, Version.Lockup.V3_0)).toBe(true);
+      expect(isVersionBefore(Version.Flow.V1_0, Version.Flow.V1_1)).toBe(true);
+      expect(isVersionBefore(Version.Airdrops.V1_2, Version.Airdrops.V2_0)).toBe(true);
+    });
+
+    it("returns false when version is after reference", () => {
+      expect(isVersionBefore(Version.Lockup.V2_0, Version.Lockup.V1_0)).toBe(false);
+      expect(isVersionBefore(Version.Lockup.V3_0, Version.Lockup.V2_0)).toBe(false);
+      expect(isVersionBefore(Version.Flow.V2_0, Version.Flow.V1_0)).toBe(false);
+    });
+
+    it("returns false when versions are equal", () => {
+      expect(isVersionBefore(Version.Lockup.V2_0, Version.Lockup.V2_0)).toBe(false);
+      expect(isVersionBefore(Version.Flow.V1_1, Version.Flow.V1_1)).toBe(false);
+    });
+
+    it("handles real-world use case: filtering contracts before V2_0", () => {
+      // This is the use case mentioned in the issue
+      const versions = [
+        Version.Lockup.V1_0,
+        Version.Lockup.V1_1,
+        Version.Lockup.V1_2,
+        Version.Lockup.V2_0,
+        Version.Lockup.V3_0,
+      ];
+
+      const beforeV2 = versions.filter((v) => isVersionBefore(v, Version.Lockup.V2_0));
+
+      expect(beforeV2).toEqual([Version.Lockup.V1_0, Version.Lockup.V1_1, Version.Lockup.V1_2]);
+    });
+  });
+
+  describe("isVersionAfter", () => {
+    it("returns true when version is after reference", () => {
+      expect(isVersionAfter(Version.Lockup.V2_0, Version.Lockup.V1_0)).toBe(true);
+      expect(isVersionAfter(Version.Lockup.V2_0, Version.Lockup.V1_1)).toBe(true);
+      expect(isVersionAfter(Version.Lockup.V3_0, Version.Lockup.V2_0)).toBe(true);
+      expect(isVersionAfter(Version.Flow.V1_1, Version.Flow.V1_0)).toBe(true);
+      expect(isVersionAfter(Version.Airdrops.V2_0, Version.Airdrops.V1_2)).toBe(true);
+    });
+
+    it("returns false when version is before reference", () => {
+      expect(isVersionAfter(Version.Lockup.V1_0, Version.Lockup.V2_0)).toBe(false);
+      expect(isVersionAfter(Version.Lockup.V2_0, Version.Lockup.V3_0)).toBe(false);
+      expect(isVersionAfter(Version.Flow.V1_0, Version.Flow.V2_0)).toBe(false);
+    });
+
+    it("returns false when versions are equal", () => {
+      expect(isVersionAfter(Version.Lockup.V2_0, Version.Lockup.V2_0)).toBe(false);
+      expect(isVersionAfter(Version.Flow.V1_1, Version.Flow.V1_1)).toBe(false);
+    });
+
+    it("handles real-world use case: filtering contracts after V1_1", () => {
+      const versions = [Version.Flow.V1_0, Version.Flow.V1_1, Version.Flow.V2_0];
+
+      const afterV1_1 = versions.filter((v) => isVersionAfter(v, Version.Flow.V1_1));
+
+      expect(afterV1_1).toEqual([Version.Flow.V2_0]);
+    });
+  });
+});


### PR DESCRIPTION
Adds runtime semantic version comparison utilities to enable chronological filtering of contracts by version.

Implements `compareVersions`, `isVersionBefore`, and `isVersionAfter` helpers that parse version strings (e.g., "v1.0", "v2.0") at runtime. This enables use cases like skipping fee handling for contracts before `Lockup.V2_0`.

Chose runtime parsing over static arrays/metadata to minimize maintenance burden and prevent drift.

Closes #53