### PR TITLE
feat: export evm and solana modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./evm";
 export * as evm from "./evm";
 export * from "./helpers";
 export * from "./sablier";


### PR DESCRIPTION
Closes https://github.com/sablier-labs/sdk/issues/96

[sablier.ts](https://github.com/sablier-labs/sdk/blob/main/src/sablier.ts) does import queries from `evm` and `solana` modules but not all of its functions. So I just the following:

```ts
export * as evm from "./evm";
export * as solana from "./solana";
```

I am not sure if its the best practices.