### PR TITLE
refactor: replace chars param with start/end options in truncateAddress

### DIFF
--- a/src/evm/helpers.ts
+++ b/src/evm/helpers.ts
@@ -1,35 +1,37 @@
 import { aliasCatalog } from "@src/evm/contracts/alias-catalog";
 import { Protocol, Version } from "@src/evm/enums";
 import { getContractExplorerURL as getContractExplorerURLInternal } from "@src/internal/utils/explorer-url";
-import type { Sablier } from "@src/types";
+import type { Sablier, TruncateAddressOptions } from "@src/types";
 
 /**
  * Truncate an Ethereum address for display purposes.
  * @param address - The Ethereum address to truncate (0x-prefixed)
- * @param chars - Number of characters to show on each side (default: 4)
+ * @param options - Truncation options with start/end character counts (default: 4 each, must be >= 1)
  * @returns Truncated address in format "0xcafe...beef" or original if too short
  * @example
  * truncateEvmAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x1234...5678"
- * truncateEvmAddress("0x1234567890abcdef1234567890abcdef12345678", 6) // "0x123456...345678"
+ * truncateEvmAddress("0x1234567890abcdef1234567890abcdef12345678", { start: 6, end: 6 }) // "0x123456...345678"
+ * truncateEvmAddress("0x1234567890abcdef1234567890abcdef12345678", { start: 2, end: 6 }) // "0x12...345678"
  * truncateEvmAddress("0x123") // "0x123" (too short, returns original)
  */
-export function truncateEvmAddress(address: Sablier.EVM.Address, chars = 4): string {
-  // Return original if empty
+export function truncateEvmAddress(
+  address: Sablier.EVM.Address,
+  options?: TruncateAddressOptions,
+): string {
   if (!address) {
     return address;
   }
 
-  // Calculate minimum length needed: "0x" + chars on each side
-  const minLength = 2 + chars * 2;
+  const start = options?.start ?? 4;
+  const end = options?.end ?? 4;
+  const minLength = 2 + start + end;
 
-  // Return original if too short to truncate meaningfully
   if (address.length <= minLength) {
     return address;
   }
 
-  // Extract prefix (0x + first chars) and suffix (last chars)
-  const prefix = address.slice(0, 2 + chars);
-  const suffix = address.slice(-chars);
+  const prefix = address.slice(0, 2 + start);
+  const suffix = end === 0 ? "" : address.slice(-end);
 
   return `${prefix}...${suffix}`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,7 @@ import { getNestedValues as getNestedValuesInternal } from "@src/internal/utils/
 import { sortChains as sortChainsInternal } from "@src/internal/utils/sort-chains";
 import { SOLANA_CHAIN_IDS } from "@src/solana/chains/chains";
 import { resolveSolanaStreamId, truncateSolanaAddress } from "@src/solana/helpers";
-import type { Sablier } from "./types";
+import type { Sablier, TruncateAddressOptions } from "./types";
 
 /** EVM-only protocols that don't exist on Solana */
 const EVM_ONLY_PROTOCOLS = new Set([EvmProtocol.Flow, EvmProtocol.Legacy]);
@@ -13,6 +13,9 @@ const EVM_ONLY_PROTOCOLS = new Set([EvmProtocol.Flow, EvmProtocol.Legacy]);
 // Re-export platform-specific helpers
 export * from "./evm/helpers";
 export * from "./solana/helpers";
+
+// Re-export shared types
+export type { TruncateAddressOptions } from "./types";
 
 /** Version type supporting both EVM and Solana protocols */
 type Version = Sablier.EVM.Version | Sablier.Solana.Version;
@@ -101,19 +104,25 @@ export function getNestedValues<T extends Record<string, unknown>>(obj: T): stri
  * Automatically routes to the appropriate typed function based on address format.
  *
  * @param address - The address to truncate (Ethereum 0x-prefixed or Solana base58)
- * @param chars - Number of characters to show on each side (default: 4)
+ * @param options - Optional truncation options with start and end character counts (default: 4 each)
  * @returns Truncated address in format "0xcafe...beef" or "DYw8...NSKK" or original if too short
  * @example
  * truncateAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x1234...5678"
- * truncateAddress("0x1234567890abcdef1234567890abcdef12345678", 6) // "0x123456...345678"
+ * truncateAddress("0x1234567890abcdef1234567890abcdef12345678", { start: 6, end: 6 }) // "0x123456...345678"
  * truncateAddress("DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK") // "DYw8...NSKK"
  * truncateAddress("0x123") // "0x123" (too short, returns original)
  */
-export function truncateAddress(address: string, chars = 4): string {
+export function truncateAddress(address: string, options?: TruncateAddressOptions): string {
   return address.startsWith("0x")
-    ? truncateEvmAddress(address as Sablier.EVM.Address, chars)
-    : truncateSolanaAddress(address, chars);
+    ? truncateEvmAddress(address as Sablier.EVM.Address, options)
+    : truncateSolanaAddress(address, options);
 }
+
+/**
+ * Convenience alias for {@link truncateAddress}.
+ * Also suitable for truncating arbitrary hex strings, not just addresses.
+ */
+export const truncate = truncateAddress;
 
 /**
  * Resolves a stream/airdrop entity ID for use with Sablier indexers.

--- a/src/solana/helpers.ts
+++ b/src/solana/helpers.ts
@@ -1,34 +1,36 @@
 import { Protocol } from "@src/solana/enums";
 import { aliasCatalog } from "@src/solana/programs/alias-catalog";
-import type { Sablier } from "@src/types";
+import type { Sablier, TruncateAddressOptions } from "@src/types";
 
 /**
  * Truncate a Solana address for display purposes.
  * @param address - The Solana address to truncate (base58 encoded)
- * @param chars - Number of characters to show on each side (default: 4)
+ * @param options - Truncation options with start/end character counts (default: 4 each, must be >= 1)
  * @returns Truncated address in format "DYw8...NSKK" or original if too short
  * @example
  * truncateSolanaAddress("DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK") // "DYw8...NSKK"
- * truncateSolanaAddress("DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK", 6) // "DYw8jC...G5CNSKK"
+ * truncateSolanaAddress("DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK", { start: 6, end: 6 }) // "DYw8jC...5CNSKK"
+ * truncateSolanaAddress("DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK", { start: 2, end: 6 }) // "DY...5CNSKK"
  * truncateSolanaAddress("abc") // "abc" (too short, returns original)
  */
-export function truncateSolanaAddress(address: Sablier.Solana.Address, chars = 4): string {
-  // Return original if empty
+export function truncateSolanaAddress(
+  address: Sablier.Solana.Address,
+  options?: TruncateAddressOptions,
+): string {
   if (!address) {
     return address;
   }
 
-  // Calculate minimum length needed: chars on each side
-  const minLength = chars * 2;
+  const start = options?.start ?? 4;
+  const end = options?.end ?? 4;
+  const minLength = start + end;
 
-  // Return original if too short to truncate meaningfully
   if (address.length <= minLength) {
     return address;
   }
 
-  // Extract prefix (first chars) and suffix (last chars)
-  const prefix = address.slice(0, chars);
-  const suffix = address.slice(-chars);
+  const prefix = address.slice(0, start);
+  const suffix = end === 0 ? "" : address.slice(-end);
 
   return `${prefix}...${suffix}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
 import * as EVMTypes from "./evm/types";
 import * as SolanaTypes from "./solana/types";
 
+/**
+ * Options for truncating blockchain addresses.
+ * @property start - Number of characters to show at the start (default: 4, must be >= 1)
+ * @property end - Number of characters to show at the end (default: 4, must be >= 1)
+ */
+export type TruncateAddressOptions = {
+  start?: number;
+  end?: number;
+};
+
 export namespace Sablier {
   export import EVM = EVMTypes.EVM;
   export import Solana = SolanaTypes.Solana;

--- a/tests/evm/helpers.test.ts
+++ b/tests/evm/helpers.test.ts
@@ -173,9 +173,9 @@ describe("helpers", () => {
     });
 
     it("truncates with custom character count", () => {
-      expect(truncate(validAddress, 2)).toBe("0x12...78");
-      expect(truncate(validAddress, 6)).toBe("0x123456...345678");
-      expect(truncate(validAddress, 8)).toBe("0x12345678...12345678");
+      expect(truncate(validAddress, { end: 2, start: 2 })).toBe("0x12...78");
+      expect(truncate(validAddress, { end: 6, start: 6 })).toBe("0x123456...345678");
+      expect(truncate(validAddress, { end: 8, start: 8 })).toBe("0x12345678...12345678");
     });
 
     it("returns original address if too short to truncate", () => {
@@ -199,20 +199,25 @@ describe("helpers", () => {
       expect(truncate("0x123456789")).toBe("0x1234...6789");
 
       // With chars=6, minLength is 14, so 15 chars should truncate
-      expect(truncate("0x1234567890abc", 6)).toBe("0x123456...890abc");
+      expect(truncate("0x1234567890abc", { end: 6, start: 6 })).toBe("0x123456...890abc");
     });
 
     it("works with real Ethereum addresses", () => {
       // Standard Ethereum address (42 characters)
       const ethAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
       expect(truncate(ethAddress)).toBe("0xd8dA...6045");
-      expect(truncate(ethAddress, 6)).toBe("0xd8dA6B...A96045");
+      expect(truncate(ethAddress, { end: 6, start: 6 })).toBe("0xd8dA6B...A96045");
     });
 
     it("preserves case sensitivity", () => {
       const checksumAddress = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf12";
       expect(truncate(checksumAddress)).toBe("0xAbCd...Ef12");
-      expect(truncate(checksumAddress, 6)).toBe("0xAbCdEf...CdEf12");
+      expect(truncate(checksumAddress, { end: 6, start: 6 })).toBe("0xAbCdEf...CdEf12");
+    });
+
+    it("supports asymmetric start/end values", () => {
+      expect(truncate(validAddress, { end: 6, start: 2 })).toBe("0x12...345678");
+      expect(truncate(validAddress, { end: 2, start: 6 })).toBe("0x123456...78");
     });
 
     describe("Solana addresses", () => {
@@ -223,27 +228,32 @@ describe("helpers", () => {
       });
 
       it("truncates Solana address with custom character count", () => {
-        expect(truncate(solanaAddress, 6)).toBe("DYw8jC...5CNSKK");
-        expect(truncate(solanaAddress, 8)).toBe("DYw8jCTf...mG5CNSKK");
+        expect(truncate(solanaAddress, { end: 6, start: 6 })).toBe("DYw8jC...5CNSKK");
+        expect(truncate(solanaAddress, { end: 8, start: 8 })).toBe("DYw8jCTf...mG5CNSKK");
+      });
+
+      it("supports asymmetric start/end values", () => {
+        expect(truncate(solanaAddress, { end: 6, start: 2 })).toBe("DY...5CNSKK");
+        expect(truncate(solanaAddress, { end: 2, start: 6 })).toBe("DYw8jC...KK");
       });
 
       it("returns original if too short", () => {
-        expect(truncate("DYw8", 4)).toBe("DYw8");
-        expect(truncate("ABC123", 4)).toBe("ABC123");
+        expect(truncate("DYw8", { end: 4, start: 4 })).toBe("DYw8");
+        expect(truncate("ABC123", { end: 4, start: 4 })).toBe("ABC123");
         expect(truncate("short")).toBe("short");
       });
 
       it("works with various Solana addresses", () => {
         const anotherSolana = "So11111111111111111111111111111111111111112";
         expect(truncate(anotherSolana)).toBe("So11...1112");
-        expect(truncate(anotherSolana, 6)).toBe("So1111...111112");
+        expect(truncate(anotherSolana, { end: 6, start: 6 })).toBe("So1111...111112");
       });
 
       it("handles non-0x addresses generically", () => {
         // Any non-0x address is treated as Solana-style
         const genericAddress = "1234567890abcdef1234567890abcdef12345678";
         expect(truncate(genericAddress)).toBe("1234...5678");
-        expect(truncate(genericAddress, 6)).toBe("123456...345678");
+        expect(truncate(genericAddress, { end: 6, start: 6 })).toBe("123456...345678");
       });
     });
   });


### PR DESCRIPTION
## Summary

- Replace the single `chars` parameter with an options object containing `start` and `end` properties for asymmetric truncation
- Move `TruncateAddressOptions` type to shared `src/types.ts` location
- Fix edge case bug where `end: 0` would return the full string instead of empty (due to `slice(-0)` behavior)
- Add `truncate` alias export for convenience
- Update JSDoc examples and add tests for asymmetric truncation on both EVM and Solana addresses

## New API

```typescript
// Before
truncateAddress("0x1234...5678", 6) // symmetric only

// After
truncateAddress("0x1234...5678", { start: 6, end: 6 }) // symmetric
truncateAddress("0x1234...5678", { start: 2, end: 6 }) // asymmetric: "0x12...345678"
```

Closes #128