### PR TITLE
refactor(solana): replace solscan with orb explorer

### DIFF
--- a/src/solana/chains/chains.ts
+++ b/src/solana/chains/chains.ts
@@ -10,11 +10,9 @@ export const SOLANA_CHAIN_IDS = new Set([CHAIN_ID_SOLANA_MAINNET_BETA, CHAIN_ID_
 
 export const solanaDevnet: Sablier.Solana.Chain = {
   blockExplorers: {
-    default: { name: "Explorer", url: "https://solscan.io?cluster=devnet" },
-    solanaFm: {
-      name: "Solana FM",
-      url: "https://solana.fm?cluster=devnet-alpha",
-    },
+    default: { name: "Orb", url: "https://orb.helius.dev?cluster=devnet" },
+    solanaFm: { name: "Solana FM", url: "https://solana.fm?cluster=devnet-alpha" },
+    solscan: { name: "Solscan", url: "https://solscan.io?cluster=devnet" },
   },
   chainlink: {
     feed: "99B2bTijsU6f1GCT73HmdR7HCFFjGMBcPZY6jZ96ynrR",
@@ -50,8 +48,9 @@ export const solanaDevnet: Sablier.Solana.Chain = {
 
 export const solanaMainnetBeta: Sablier.Solana.Chain = {
   blockExplorers: {
-    default: { name: "Explorer", url: "https://solscan.io" },
+    default: { name: "Orb", url: "https://orb.helius.dev" },
     solanaFm: { name: "Solana FM", url: "https://solana.fm" },
+    solscan: { name: "Solscan", url: "https://solscan.io" },
   },
   chainlink: {
     feed: "99B2bTijsU6f1GCT73HmdR7HCFFjGMBcPZY6jZ96ynrR",


### PR DESCRIPTION
## Summary

Replaces the default Solana block explorer from Solscan to [Orb](https://orb.helius.dev) (Helius's new explorer).

## Changes

- Set Orb as default explorer for both mainnet and devnet
- Preserve Solscan and Solana FM as secondary explorers

## Verification

- URLs verified working (orb.helius.dev is canonical, redirects to orbmarkets.io)
- TypeScript: passed
- Tests: 17 passed
- Lint: passed

Closes #127