### PR TITLE
feat(contracts): add getLatestByName query method

### DIFF
--- a/src/internal/factories/queries.ts
+++ b/src/internal/factories/queries.ts
@@ -93,6 +93,7 @@ export function createContractsQueries<
   catalog: TCatalog;
   releasesQueries: {
     getAll: (opts?: { protocol?: TProtocol }) => TRelease[];
+    getLatest: (opts: { protocol: TProtocol }) => TRelease;
   };
   protocols: TProtocol[];
   normalizeAddress: (address: string) => string;
@@ -271,6 +272,22 @@ export function createContractsQueries<
         if (contract) return contract;
       }
       return undefined;
+    },
+
+    /**
+     * Get the latest contract by name for a protocol.
+     * - { chainId, contractName, protocol }
+     */
+    getLatestByName: (opts: {
+      chainId: number;
+      contractName: string;
+      protocol: TProtocol;
+    }): TContract | undefined => {
+      const { chainId, contractName, protocol } = opts;
+      const release = releasesQueries.getLatest({ protocol });
+      const dep = _.find(release.deployments, { chainId }) as TDeployment | undefined;
+      const items = getItems(dep);
+      return (_.find(items, { name: contractName }) as TContract | undefined) || undefined;
     },
   };
 }

--- a/tests/evm/contracts/queries.test.ts
+++ b/tests/evm/contracts/queries.test.ts
@@ -107,3 +107,19 @@ describe("contractsQueries.get", () => {
     });
   });
 });
+
+describe("contractsQueries.getLatestByName", () => {
+  it("should return contract from the latest release", () => {
+    const release = sablier.evm.releases.getLatest({ protocol: "lockup" });
+    const deployment = release.deployments[0];
+    const contract = deployment.contracts[0];
+
+    const result = sablier.evm.contracts.getLatestByName({
+      chainId: deployment.chainId,
+      contractName: contract.name,
+      protocol: release.protocol,
+    });
+
+    expect(result).toStrictEqual(contract);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `getLatestByName` method to contracts queries that retrieves a contract from the latest release by name
- Provides a convenience API to avoid manually fetching the latest release first

## Test plan

- [x] Unit test added verifying contract retrieval from latest release