### PR TITLE
feat(evm): add BattleChain testnet chain definition

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@solana/web3.js": "^1.98.4",
-        "viem": "^2.47.5",
+        "viem": "^2.47.10",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
@@ -591,7 +591,7 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "ox": ["ox@0.14.5", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q=="],
+    "ox": ["ox@0.14.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ=="],
 
     "oxc-resolver": ["oxc-resolver@11.16.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.16.2", "@oxc-resolver/binding-android-arm64": "11.16.2", "@oxc-resolver/binding-darwin-arm64": "11.16.2", "@oxc-resolver/binding-darwin-x64": "11.16.2", "@oxc-resolver/binding-freebsd-x64": "11.16.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.16.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.16.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.16.2", "@oxc-resolver/binding-linux-arm64-musl": "11.16.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.16.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.16.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.16.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.16.2", "@oxc-resolver/binding-linux-x64-gnu": "11.16.2", "@oxc-resolver/binding-linux-x64-musl": "11.16.2", "@oxc-resolver/binding-openharmony-arm64": "11.16.2", "@oxc-resolver/binding-wasm32-wasi": "11.16.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.16.2", "@oxc-resolver/binding-win32-ia32-msvc": "11.16.2", "@oxc-resolver/binding-win32-x64-msvc": "11.16.2" } }, "sha512-Uy76u47vwhhF7VAmVY61Srn+ouiOobf45MU9vGct9GD2ARy6hKoqEElyHDB0L+4JOM6VLuZ431KiLwyjI/A21g=="],
 
@@ -737,7 +737,7 @@
 
     "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
-    "viem": ["viem@2.47.5", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.5", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g=="],
+    "viem": ["viem@2.47.10", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.7", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-D+l6SDDZWB5bh8u9hgICzMX2/egMrgEQ+Pef/QkZgmOl6bOTyCQMSgWAH8jZTWJ/218J9QNv7s/9BH6Wu5oPDg=="],
 
     "vite": ["vite@7.2.6", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@solana/web3.js": "^1.98.4",
-    "viem": "^2.47.5"
+    "viem": "^2.47.10"
   },
   "peerDependencies": {
     "@coral-xyz/anchor": "^0.30",

--- a/src/evm/chains/chains.ts
+++ b/src/evm/chains/chains.ts
@@ -46,4 +46,14 @@ export const {
 /*                             CUSTOM DEFINITIONS                             */
 /* -------------------------------------------------------------------------- */
 
-export const { chiliz, denergy, monad, sei, sophon, tangle, zksync, zksyncSepolia } = chains;
+export const {
+  battlechainTestnet,
+  chiliz,
+  denergy,
+  monad,
+  sei,
+  sophon,
+  tangle,
+  zksync,
+  zksyncSepolia,
+} = chains;

--- a/src/evm/chains/specs.ts
+++ b/src/evm/chains/specs.ts
@@ -5,6 +5,7 @@ import {
   avalanche as _avalanche,
   base as _base,
   baseSepolia as _baseSepolia,
+  battlechainTestnet as _battlechainTestnet,
   berachain as _berachain,
   blast as _blast,
   bsc as _bsc,
@@ -144,6 +145,19 @@ export const chainSpecs = {
     rpc: {
       alchemy: "base-sepolia",
       infura: "base-sepolia",
+    },
+  },
+  /* -------------------------------------------------------------------------- */
+  /*                           BATTLECHAIN TESTNET                              */
+  /* -------------------------------------------------------------------------- */
+  battlechainTestnet: {
+    base: _battlechainTestnet,
+    meta: {
+      isZk: true,
+      slug: "battlechain-testnet",
+    },
+    nativeCurrency: {
+      coinGeckoId: COIN_GECKO.eth,
     },
   },
   /* -------------------------------------------------------------------------- */

--- a/tests/evm/helpers/missing.ts
+++ b/tests/evm/helpers/missing.ts
@@ -82,7 +82,7 @@ const INVALID_BROADCASTS: InvalidBroadcastMap = {
 };
 
 // Chains for which we completely lack broadcasts.
-const MISSING_CHAIN_ENTRIES = [chains.ronin, chains.tangle] as const;
+const MISSING_CHAIN_ENTRIES = [chains.battlechainTestnet, chains.ronin, chains.tangle] as const;
 export const MISSING_CHAIN_IDS: number[] = MISSING_CHAIN_ENTRIES.map((c) => c.id);
 export const MISSING_CHAIN_SLUGS: string[] = MISSING_CHAIN_ENTRIES.map((c) => c.slug);
 


### PR DESCRIPTION
Bump viem to 2.47.10 for the battlechainTestnet export and register the chain as a ZK testnet with no deployments.