### PR TITLE
Fix the CI failing due to lack of build before check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           save-cache: true
 
+      - name: Build the project
+        run: just build
+
       - name: Run the code checks
         run: just full-check
 


### PR DESCRIPTION
The CI is failing: https://github.com/sablier-labs/sdk/actions/runs/24244155565/job/70785934552

The `package-exports` test imports from the built `sablier` package, so `just build` must run before `just full-check`.