### PR TITLE
fix(airdrops): ship real v1.3 SablierMerkleLockup ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ The format is based on [Common Changelog](https://common-changelog.org/).
   into its contracts
 - Add `usesComptroller(release)` helper for querying Comptroller integration across Airdrops, Flow, and Lockup releases
 
+### Fixed
+
+- Replace misplaced v2.0+ ABI shipped under airdrops v1.3 for `SablierMerkleLockup` with the real v1.3 ABI (immutable
+  `FEE` pattern, `LOCKUP` naming, no oracle-driven min-fee entries)
+  ([#174](https://github.com/sablier-labs/sdk/issues/174))
+
 ## [3.9.0] - 2026-04-16
 
 ### Added

--- a/abi/airdrops/v1.3/SablierMerkleLockup.json
+++ b/abi/airdrops/v1.3/SablierMerkleLockup.json
@@ -27,6 +27,32 @@
   },
   {
     "type": "function",
+    "name": "FEE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "LOCKUP",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract ISablierLockup"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "MERKLE_ROOT",
     "inputs": [],
     "outputs": [
@@ -34,32 +60,6 @@
         "name": "",
         "type": "bytes32",
         "internalType": "bytes32"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "ORACLE",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "SABLIER_LOCKUP",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract ISablierLockup"
       }
     ],
     "stateMutability": "view"
@@ -118,19 +118,6 @@
   },
   {
     "type": "function",
-    "name": "calculateMinFeeWei",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "campaignName",
     "inputs": [],
     "outputs": [
@@ -172,25 +159,6 @@
   },
   {
     "type": "function",
-    "name": "claimedStreams",
-    "inputs": [
-      {
-        "name": "recipient",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "clawback",
     "inputs": [
       {
@@ -228,7 +196,7 @@
   },
   {
     "type": "function",
-    "name": "firstClaimTime",
+    "name": "getFirstClaimTime",
     "inputs": [],
     "outputs": [
       {
@@ -286,33 +254,7 @@
   },
   {
     "type": "function",
-    "name": "lowerMinFeeUSD",
-    "inputs": [
-      {
-        "name": "newMinFeeUSD",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "minFeeUSD",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "streamShape",
+    "name": "shape",
     "inputs": [],
     "outputs": [
       {
@@ -335,31 +277,6 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
-  },
-  {
-    "type": "event",
-    "name": "Claim",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "recipient",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint128",
-        "indexed": false,
-        "internalType": "uint128"
-      }
-    ],
-    "anonymous": false
   },
   {
     "type": "event",
@@ -413,31 +330,6 @@
         "type": "uint128",
         "indexed": false,
         "internalType": "uint128"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "LowerMinFeeUSD",
-    "inputs": [
-      {
-        "name": "factoryAdmin",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newMinFeeUSD",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "previousMinFeeUSD",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
       }
     ],
     "anonymous": false
@@ -522,22 +414,6 @@
   },
   {
     "type": "error",
-    "name": "SablierMerkleBase_CallerNotFactoryAdmin",
-    "inputs": [
-      {
-        "name": "factoryAdmin",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "SablierMerkleBase_CampaignExpired",
     "inputs": [
       {
@@ -591,17 +467,6 @@
   },
   {
     "type": "error",
-    "name": "SablierMerkleBase_IndexClaimed",
-    "inputs": [
-      {
-        "name": "index",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
     "name": "SablierMerkleBase_InsufficientFeePayment",
     "inputs": [
       {
@@ -610,7 +475,7 @@
         "internalType": "uint256"
       },
       {
-        "name": "minFeeWei",
+        "name": "fee",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -623,15 +488,10 @@
   },
   {
     "type": "error",
-    "name": "SablierMerkleBase_NewMinFeeUSDNotLower",
+    "name": "SablierMerkleBase_StreamClaimed",
     "inputs": [
       {
-        "name": "currentMinFeeUSD",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "newMinFeeUSD",
+        "name": "index",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/src/evm/releases/airdrops/v1.3/abi/SablierMerkleLockup.ts
+++ b/src/evm/releases/airdrops/v1.3/abi/SablierMerkleLockup.ts
@@ -15,22 +15,22 @@ export const sablierMerkleLockupAbi = [
   },
   {
     inputs: [],
+    name: "FEE",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "LOCKUP",
+    outputs: [{ internalType: "contract ISablierLockup", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "MERKLE_ROOT",
     outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "ORACLE",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "SABLIER_LOCKUP",
-    outputs: [{ internalType: "contract ISablierLockup", name: "", type: "address" }],
     stateMutability: "view",
     type: "function",
   },
@@ -64,13 +64,6 @@ export const sablierMerkleLockupAbi = [
   },
   {
     inputs: [],
-    name: "calculateMinFeeWei",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
     name: "campaignName",
     outputs: [{ internalType: "string", name: "", type: "string" }],
     stateMutability: "view",
@@ -86,13 +79,6 @@ export const sablierMerkleLockupAbi = [
     name: "claim",
     outputs: [],
     stateMutability: "payable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "recipient", type: "address" }],
-    name: "claimedStreams",
-    outputs: [{ internalType: "uint256[]", name: "", type: "uint256[]" }],
-    stateMutability: "view",
     type: "function",
   },
   {
@@ -114,7 +100,7 @@ export const sablierMerkleLockupAbi = [
   },
   {
     inputs: [],
-    name: "firstClaimTime",
+    name: "getFirstClaimTime",
     outputs: [{ internalType: "uint40", name: "", type: "uint40" }],
     stateMutability: "view",
     type: "function",
@@ -141,22 +127,8 @@ export const sablierMerkleLockupAbi = [
     type: "function",
   },
   {
-    inputs: [{ internalType: "uint256", name: "newMinFeeUSD", type: "uint256" }],
-    name: "lowerMinFeeUSD",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
     inputs: [],
-    name: "minFeeUSD",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "streamShape",
+    name: "shape",
     outputs: [{ internalType: "string", name: "", type: "string" }],
     stateMutability: "view",
     type: "function",
@@ -167,16 +139,6 @@ export const sablierMerkleLockupAbi = [
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: false, internalType: "uint256", name: "index", type: "uint256" },
-      { indexed: true, internalType: "address", name: "recipient", type: "address" },
-      { indexed: false, internalType: "uint128", name: "amount", type: "uint128" },
-    ],
-    name: "Claim",
-    type: "event",
   },
   {
     anonymous: false,
@@ -197,16 +159,6 @@ export const sablierMerkleLockupAbi = [
       { indexed: false, internalType: "uint128", name: "amount", type: "uint128" },
     ],
     name: "Clawback",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "factoryAdmin", type: "address" },
-      { indexed: false, internalType: "uint256", name: "newMinFeeUSD", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "previousMinFeeUSD", type: "uint256" },
-    ],
-    name: "LowerMinFeeUSD",
     type: "event",
   },
   {
@@ -247,14 +199,6 @@ export const sablierMerkleLockupAbi = [
   },
   {
     inputs: [
-      { internalType: "address", name: "factoryAdmin", type: "address" },
-      { internalType: "address", name: "caller", type: "address" },
-    ],
-    name: "SablierMerkleBase_CallerNotFactoryAdmin",
-    type: "error",
-  },
-  {
-    inputs: [
       { internalType: "uint256", name: "blockTimestamp", type: "uint256" },
       { internalType: "uint40", name: "expiration", type: "uint40" },
     ],
@@ -279,25 +223,17 @@ export const sablierMerkleLockupAbi = [
     type: "error",
   },
   {
-    inputs: [{ internalType: "uint256", name: "index", type: "uint256" }],
-    name: "SablierMerkleBase_IndexClaimed",
-    type: "error",
-  },
-  {
     inputs: [
       { internalType: "uint256", name: "feePaid", type: "uint256" },
-      { internalType: "uint256", name: "minFeeWei", type: "uint256" },
+      { internalType: "uint256", name: "fee", type: "uint256" },
     ],
     name: "SablierMerkleBase_InsufficientFeePayment",
     type: "error",
   },
   { inputs: [], name: "SablierMerkleBase_InvalidProof", type: "error" },
   {
-    inputs: [
-      { internalType: "uint256", name: "currentMinFeeUSD", type: "uint256" },
-      { internalType: "uint256", name: "newMinFeeUSD", type: "uint256" },
-    ],
-    name: "SablierMerkleBase_NewMinFeeUSDNotLower",
+    inputs: [{ internalType: "uint256", name: "index", type: "uint256" }],
+    name: "SablierMerkleBase_StreamClaimed",
     type: "error",
   },
   {


### PR DESCRIPTION
Replaces the misplaced v2.0+ ABI shipped under `airdrops/v1.3` for `SablierMerkleLockup` with the actual v1.3 ABI, sourced from [sablier-labs/airdrops@1.3.0](https://github.com/sablier-labs/airdrops/tree/v1.3.0). The old payload exposed the oracle-driven min-fee model (`ORACLE`, `calculateMinFeeWei`, `minFeeUSD`, `lowerMinFeeUSD`) and the v2.0 `SABLIER_LOCKUP` rename, so any consumer resolving this ABI against a real v1.3 MerkleLL/MerkleLT campaign would mis-simulate calls and fail to decode `FEE()`.

The fixed ABI uses the immutable `FEE` pattern, the pre-v2.0 `LOCKUP` naming, and drops the v2.0-only entries. Since v1.3 has no concrete `SablierMerkleLockup` contract, the ABI reflects the shared Lockup-level interface between `SablierMerkleLL` and `SablierMerkleLT` (base functions + `LOCKUP`, `STREAM_CANCELABLE`, `STREAM_TRANSFERABLE`, and the `Claim` event with `streamId`).

Closes #174