### PR TITLE
chore: bump version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 > Starting with v2.0.0, this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). In v1.x, it
 > did not always follow Semantic Versioning.
 
+[4.0.0]: https://github.com/sablier-labs/sdk/releases/tag/v4.0.0
 [3.9.0]: https://github.com/sablier-labs/sdk/releases/tag/v3.9.0
 [3.8.0]: https://github.com/sablier-labs/sdk/releases/tag/v3.8.0
 [3.7.5]: https://github.com/sablier-labs/sdk/releases/tag/v3.7.5
@@ -50,7 +51,7 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 [1.1.0]: https://github.com/sablier-labs/sdk/releases/tag/v1.1.0
 [1.0.0]: https://github.com/sablier-labs/sdk/releases/tag/v1.0.0
 
-## Unreleased
+## [4.0.0] - 2026-04-21
 
 ### Added
 
@@ -58,6 +59,11 @@ The format is based on [Common Changelog](https://common-changelog.org/).
   tracking whether a release wires a Comptroller reference (`ISablierComptroller` or the legacy `ISablierV2Comptroller`)
   into its contracts
 - Add `usesComptroller(release)` helper for querying Comptroller integration across Airdrops, Flow, and Lockup releases
+
+### Changed
+
+- **Breaking:** Change comptroller release version from `v2.0` to `v1.1`
+  ([#177](https://github.com/sablier-labs/sdk/pulls/177))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "types": "./dist/types/index.d.ts",
   "typings": "./dist/types/index.d.ts",
-  "version": "3.9.0",
+  "version": "4.0.0",
   "type": "module",
   "author": {
     "name": "Sablier Labs Ltd",


### PR DESCRIPTION
remove the `Unreleased` header and added those changes in the `4.0.0`

depends on https://github.com/sablier-labs/sdk/pull/177 being merged first